### PR TITLE
Ability to import glmnet_python without loading matplotlib

### DIFF
--- a/glmnet_python/cvglmnetPlot.py
+++ b/glmnet_python/cvglmnetPlot.py
@@ -127,6 +127,3 @@ def cvglmnetPlot(cvobject, sign_lambda = 1.0, **options):
     ax1.set_ylabel(cvobject['name'])
     
     #plt.show()
-
-    
-    

--- a/glmnet_python/cvglmnetPlot.py
+++ b/glmnet_python/cvglmnetPlot.py
@@ -65,9 +65,10 @@
 """
 
 import scipy
-import matplotlib.pyplot as plt
+
 
 def cvglmnetPlot(cvobject, sign_lambda = 1.0, **options):
+    import matplotlib.pyplot as plt
     
     sloglam = sign_lambda*scipy.log(cvobject['lambdau'])
 

--- a/glmnet_python/glmnetPlot.py
+++ b/glmnet_python/glmnetPlot.py
@@ -71,10 +71,11 @@
      plt.figure()
      glmnetPlot(fit3)
 """
-import matplotlib.pyplot as plt
 import scipy
 
+
 def glmnetPlot(x, xvar = 'norm', label = False, ptype = 'coef', **options):
+    import matplotlib.pyplot as plt
 
     # process inputs
     xvar = getFromList(xvar, ['norm', 'lambda', 'dev'], 'xvar should be one of ''norm'', ''lambda'', ''dev'' ')    
@@ -154,6 +155,8 @@ def nonzeroCoef(beta, bystep = False):
 # end of nonzeroCoef()
 # =========================================
 def plotCoef(beta, norm, lambdau, df, dev, label, xvar, xlab, ylab, **options):
+    import matplotlib.pyplot as plt
+
     which = nonzeroCoef(beta)
     idwhich = [i for i in range(len(which)) if which[i] == True]
     nwhich = len(idwhich)


### PR DESCRIPTION
It is often the case that you don't need the plotting functionalities, therefore, you don't have to install matplotlib. Currently, when you import glmnet_python the plotting methods also automatically gets loaded - and if you don't have matplotlib installed, the code crashes with an ImportError.  I have therefore, moved the matplotlib imports inside the relevant methods. Please keep in mind, installing matplotlib on CentOS or Ubuntu servers is not a trivial task as well.