### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ hanfang.cshl@gmail.com
 
 Using pip (recommended)
     
-    pip install glmnet_python
+    pip install glmnet_py
 
 Complied from source
 


### PR DESCRIPTION
`pip install glmnet_python` doesn't work, `pip install glmnet_py` does.