### PR TITLE
Fix missing colon after else statement and re-add missing scipy.dot to calculation

### DIFF
--- a/glmnet_python/cvglmnet.py
+++ b/glmnet_python/cvglmnet.py
@@ -277,7 +277,7 @@ def cvglmnet(*, x,
     if parallel != 1:
         if parallel == -1:
             num_cores = multiprocessing.cpu_count()
-        else
+        else:
             num_cores = parallel
         sys.stderr.write("[status]\tParallel glmnet cv with " + str(num_cores) + " cores\n")
         cpredmat = joblib.Parallel(n_jobs=num_cores)(joblib.delayed(doCV)(i, x, y, family, foldid, nfolds, is_offset, **options) for i in range(nfolds))

--- a/glmnet_python/glmnetPredict.py
+++ b/glmnet_python/glmnetPredict.py
@@ -163,7 +163,7 @@ def glmnetPredict(fit,\
             result = nonzeroCoef(nbeta[1:nbeta.shape[0], :], True)
             return(result)
         # use scipy.sparse.hstack instead of column_stack for sparse matrices        
-        result = (scipy.column_stack( (scipy.ones([newx.shape[0], 1]) , newx) ) , nbeta)
+        result = scipy.dot(scipy.column_stack( (scipy.ones([newx.shape[0], 1]) , newx) ) , nbeta)
         
         if fit['offset']:
             if len(offset) == 0:


### PR DESCRIPTION
Hi, 
- In https://github.com/bbalasub1/glmnet_python/pull/29 a change was introduced that misses a colon after an else statement
- In https://github.com/bbalasub1/glmnet_python/pull/30 a dot product was removed

This PR adds the missing colon and re-adds the scipy.dot() call. Our own unit tests that use (parts of) this library work again with these changes